### PR TITLE
add instance-db-name annotation

### DIFF
--- a/kubernetes/api/v1alpha1/databaseclass.go
+++ b/kubernetes/api/v1alpha1/databaseclass.go
@@ -52,6 +52,7 @@ const (
 	AnnotationsAvailabilityZones   = "databaseclass.database-mesh.io/availability-zones"
 	AnnotationsClusterIdentifier   = "databaseclass.database-mesh.io/cluster-identifier"
 	AnnotationsInstanceIdentifier  = "databaseclass.database-mesh.io/instance-identifier"
+	AnnotationsInstanceDBName      = "databaseclass.database-mesh.io/instance-db-name"
 	AnnotationsSnapshotIdentifier  = "databaseclass.database-mesh.io/snapshot-identifier"
 	AnnotationsMasterUsername      = "databaseclass.database-mesh.io/master-username"
 	AnnotationsMasterUserPassword  = "databaseclass.database-mesh.io/master-user-password"


### PR DESCRIPTION
Add annotation `"databaseclass.database-mesh.io/instance-db-name"` for set default database name when create aws rds instance.