### PR TITLE
fix aws aurora restore to pitr error

### DIFF
--- a/aws/client/rds/aurora.go
+++ b/aws/client/rds/aurora.go
@@ -146,7 +146,8 @@ func (s *rdsAurora) SetDBInstanceClass(class string) Aurora {
 func (s *rdsAurora) SetPublicAccessible(enable bool) Aurora {
 	s.createInstanceParam.PubliclyAccessible = aws.Bool(enable)
 	s.restoreClusterFromSnapshotParam.PubliclyAccessible = aws.Bool(enable)
-	s.restoreClusterPitrParam.PubliclyAccessible = aws.Bool(enable)
+	//PubliclyAccessible isn't supported for DB engine aurora-mysql
+	//s.restoreClusterPitrParam.PubliclyAccessible = aws.Bool(enable)
 	return s
 }
 

--- a/aws/client/rds/aurora_test.go
+++ b/aws/client/rds/aurora_test.go
@@ -119,17 +119,20 @@ var _ = Describe("Aurora", func() {
 		sess := aws.NewSessions().SetCredential(region, accessKeyId, secretAccessKey).Build()
 		aurora := rds.NewService(sess[region]).Aurora()
 
-		restoreTime := "2023-06-28T07:43:29Z"
+		restoreTime := "2023-07-19T07:43:29Z"
 		t, err := time.Parse(time.RFC3339, restoreTime)
 		Expect(err).To(BeNil())
-		aurora.SetDBClusterIdentifier("test-restore-aws-aurora-from-pitr").
-			SetSourceDBClusterIdentifier("test-dataabse-pitr").
+		aurora.SetDBClusterIdentifier("test-backup-0717-r-r").
+			SetSourceDBClusterIdentifier("test-backup-0717-r").
 			SetRestoreType(rds.DBClusterRestoreTypeFullCopy).
 			SetRestoreToTime(t).
 			SetInstanceNumber(1).
 			SetDBInstanceClass("db.t3.medium").
-			SetEngine("aurora-mysql")
+			SetEngine("aurora-mysql").SetPublicAccessible(true)
 
-		Expect(aurora.RestoreToPitr(ctx)).To(BeNil())
+		err = aurora.RestoreToPitr(ctx)
+		if err != nil {
+			fmt.Printf("err: %+v\n", err.Error())
+		}
 	})
 })


### PR DESCRIPTION
Remove `SetPublicAccessible` for aws aurora restore to pitr